### PR TITLE
Fixed typo in README and adding dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These instructions assume an Arch Linux-based distribution. Hyprland is not pres
 
 4. Copy dotfiles into your config directory (assumptions made).
 
-    `cp -ri garden-hyprland-dotfiles/* $HOME/.config/`
+    `cp -ri hyprland-dotfiles/* $HOME/.config/`
 
 ## Configuration
 


### PR DESCRIPTION
Fixed from `cp -ri garden-hyprland-dotfiles/* $HOME/.config/` to `cp -ri hyprland-dotfiles/* $HOME/.config/` because `garden-hyprland-dotfiles` does not exist.