### PR TITLE
Fixed path xdg-desktop-portal-hyprland

### DIFF
--- a/hypr/scripts/xdph
+++ b/hypr/scripts/xdph
@@ -3,6 +3,6 @@ sleep 1
 killall xdg-desktop-portal-hyprland
 killall xdg-desktop-portal-wlr
 killall xdg-desktop-portal
-/usr/libexec/xdg-desktop-portal-hyprland &
+/usr/lib/xdg-desktop-portal-hyprland &
 sleep 2
 /usr/lib/xdg-desktop-portal &


### PR DESCRIPTION
xdg-desktop-portal-hyprland will be installed in `/usr/lib/` instead of `/usr/libexec`.